### PR TITLE
Updated directions for building from source to point to sergeche/tea-for-coda.git

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,7 +26,7 @@ If you want to try the latest development version of Coda, you can download
 and build the plugin from source (easy_install py2app if you don't already
 have it) like so:
 
-	git clone git://github.com/onecrayon/tea-for-coda.git
+	git clone git://github.com/sergeche/tea-for-coda.git
 	cd tea-for-coda
 	python setup.py py2app
 


### PR DESCRIPTION
(instead of onecrayon’s deprecated repo)
